### PR TITLE
xiaomi-tucana: Add libssc-180-degrees mount matrix to dependencies

### DIFF
--- a/device/testing/device-xiaomi-tucana/APKBUILD
+++ b/device/testing/device-xiaomi-tucana/APKBUILD
@@ -2,7 +2,7 @@
 pkgname=device-xiaomi-tucana
 pkgdesc="Xiaomi Mi Note 10"
 pkgver=1
-pkgrel=0
+pkgrel=1
 url="https://postmarketos.org"
 license="MIT"
 arch="aarch64"
@@ -21,6 +21,7 @@ depends="
 	mkbootimg
 	postmarketos-base
 	soc-qcom-sm7150
+	soc-qcom-sm7150-libssc-180-degrees
 	soc-qcom-sm7150-nonfree-firmware
 "
 makedepends="devicepkg-dev"


### PR DESCRIPTION
This fixes auto-rotation, because sensor is mounted at 180 degrees.